### PR TITLE
Move-robot-ip-address-configuration-to-ros-launch-file-in-kinova-driver

### DIFF
--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -71,17 +71,19 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle, boost::recursive_mute
   // Set ethernet parameters
   EthernetCommConfig ethernet_settings;
   std::string local_IP, subnet_mask;
+  std::string inet_addr_string;
   int local_cmd_port, local_bcast_port;
   node_handle.getParam("ethernet/local_machine_IP", local_IP);
   node_handle.getParam("ethernet/subnet_mask", subnet_mask);
   node_handle.getParam("ethernet/local_cmd_port", local_cmd_port);
   node_handle.getParam("ethernet/local_broadcast_port", local_bcast_port);
+  node_handle.getParam("robotIpAddress", inet_addr_string);
   ethernet_settings.localCmdport = local_cmd_port;
   ethernet_settings.localBcastPort = local_bcast_port;
   ethernet_settings.localIpAddress = inet_addr(local_IP.c_str());
   ethernet_settings.subnetMask = inet_addr(subnet_mask.c_str());
   ethernet_settings.rxTimeOutInMs = 1000;
-  ethernet_settings.robotIpAddress = inet_addr("192.168.100.11");
+  ethernet_settings.robotIpAddress = inet_addr(inet_addr_string.c_str());
   ethernet_settings.robotPort = 55000;
 
   // Get the serial number parameter for the arm we wish to connect to

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -77,7 +77,7 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle, boost::recursive_mute
   node_handle.getParam("ethernet/subnet_mask", subnet_mask);
   node_handle.getParam("ethernet/local_cmd_port", local_cmd_port);
   node_handle.getParam("ethernet/local_broadcast_port", local_bcast_port);
-  node_handle.getParam("robotIpAddress", inet_addr_string);
+  node_handle.getParam("kinovaControllerIpAddress", inet_addr_string);
   ethernet_settings.localCmdport = local_cmd_port;
   ethernet_settings.localBcastPort = local_bcast_port;
   ethernet_settings.localIpAddress = inet_addr(local_IP.c_str());

--- a/ovis_bringup/launch/ovis_arm.launch
+++ b/ovis_bringup/launch/ovis_arm.launch
@@ -3,12 +3,14 @@
   <arg name="kinova_robotType" default="c2s6s000" />
   <arg name="kinova_robotName" default="ovis" />
   <arg name="kinova_robotSerial" default="not_set" />
+  <arg name="robotIpAddress" default="192.168.84.160" />
   <arg name="use_jaco_v1_fingers" default="false" />
   <arg name="feedback_publish_rate" default="0.1" />
 
   <node name="$(arg kinova_robotName)" pkg="kinova_driver" type="kinova_arm_driver" output="screen" cwd="node" args="$(arg kinova_robotType)" respawn="true">
     <rosparam file="$(find ovis_bringup)/launch/config/ovis_parameters.yaml" command="load" />
     <param name="serial_number" value="$(arg kinova_robotSerial)" />
+    <param name="robotIpAddress" value="$(arg robotIpAddress)" />
     <param name="robot_name" value="$(arg kinova_robotName)" />
     <param name="robot_type" value="$(arg kinova_robotType)" />
     <param name="use_jaco_v1_fingers" value="$(arg use_jaco_v1_fingers)" />

--- a/ovis_bringup/launch/ovis_arm.launch
+++ b/ovis_bringup/launch/ovis_arm.launch
@@ -3,14 +3,14 @@
   <arg name="kinova_robotType" default="c2s6s000" />
   <arg name="kinova_robotName" default="ovis" />
   <arg name="kinova_robotSerial" default="not_set" />
-  <arg name="robotIpAddress" default="192.168.84.160" />
+  <arg name="kinovaControllerIpAddress" default="192.168.84.160" />
   <arg name="use_jaco_v1_fingers" default="false" />
   <arg name="feedback_publish_rate" default="0.1" />
 
   <node name="$(arg kinova_robotName)" pkg="kinova_driver" type="kinova_arm_driver" output="screen" cwd="node" args="$(arg kinova_robotType)" respawn="true">
     <rosparam file="$(find ovis_bringup)/launch/config/ovis_parameters.yaml" command="load" />
     <param name="serial_number" value="$(arg kinova_robotSerial)" />
-    <param name="robotIpAddress" value="$(arg robotIpAddress)" />
+    <param name="kinovaControllerIpAddress" value="$(arg kinovaControllerIpAddress)" />
     <param name="robot_name" value="$(arg kinova_robotName)" />
     <param name="robot_type" value="$(arg kinova_robotType)" />
     <param name="use_jaco_v1_fingers" value="$(arg use_jaco_v1_fingers)" />


### PR DESCRIPTION
This patch add a new parameter, "kinovaControllerIpAddress", to specify the IP address of the Kinova controller.

This patch was originally part of #37